### PR TITLE
Size fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,22 +280,23 @@ func showTotalImageSize(c *cli.Context) error {
 			return cli.NewExitError(err.Error(), 1)
 		}
 
+		sizeInfo := make(map[string]int64)
+
 		for _, tag := range tags {
 			manifest, err := r.ImageManifest(imgName, tag)
 			if err != nil {
 				return cli.NewExitError(err.Error(), 1)
 			}
 
-			sizeInfo := make(map[string]int64)
-
 			for _, layer := range manifest.Layers {
 				sizeInfo[layer.Digest] = layer.Size
 			}
 
-			for _, size := range sizeInfo {
-				totalSize += size
-			}
 		}
+		for _, size := range sizeInfo {
+			totalSize += size
+		}
+
 		fmt.Printf("%d %s\n", totalSize, imgName)
 	}
 	return nil

--- a/sorter.go
+++ b/sorter.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+// 	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,7 +43,7 @@ func extractNumberFromString(str string) (num int) {
 	// If the operation fails , do the same strSlice thow it to the end.
 	if err != nil {
 		return 1 << 32
-		//log.Fatal(err)
+		//log.Info(err)
 	}
 	return num
 }

--- a/sorter.go
+++ b/sorter.go
@@ -40,8 +40,10 @@ func extractNumberFromString(str string) (num int) {
 	}
 
 	num, err := strconv.Atoi(strings.Join(strSlice, ""))
+	// If the operation fails , do the same strSlice thow it to the end.
 	if err != nil {
-		log.Fatal(err)
+		return 1 << 32
+		//log.Fatal(err)
 	}
 	return num
 }


### PR DESCRIPTION
### Description
 Importing changes needed for removing duplicate size on base layers
 Sorting issues on long tags without numeric values

### Related Issue

- Base layer sizes are counted in every tag
- Some tags cause issues with sorting resulting in a crash
